### PR TITLE
Update error in new fuse build

### DIFF
--- a/Device.uno
+++ b/Device.uno
@@ -37,7 +37,7 @@ public sealed class Device : NativeModule {
 
     public Device() : base() {
         if (_instance != null) return;
-        Resource.SetGlobalKey(_instance = this, "Device");
+        Uno.UX.Resource.SetGlobalKey(_instance = this, "Device");
 
         AddMember(new NativeProperty< string, object >("vendor", Vendor));
         AddMember(new NativeProperty< string, object >("model", Model));


### PR DESCRIPTION
Fuse detect an error in resource call (fuse v 0.36.0 build 11838), you need use Uno.UX.Resource to work correctly. Nice work this help me a lot in my proyects.